### PR TITLE
remove unnecessary requests module import

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 import json
-import requests
 
 
 def test_health(client):


### PR DESCRIPTION
This import line is not needed. Runing pytest is causing a problem where requests module cannot be found.